### PR TITLE
Try distribits.live as baseurl

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = 'https://datalad.github.io/distribits-2024-website/'
+baseURL = 'https://distribits.live'
 languageCode = 'en-us'
 title = 'distribits'
 theme = "PaperMod"


### PR DESCRIPTION
This is to try and fix the styling problems on the current live site, see https://github.com/datalad/distribits-2024-website/issues/4