### PR TITLE
Add call for participation

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,8 +8,8 @@ theme = "PaperMod2"
 [params]
   [params.profileMode]
     enabled = true
-    title = 'Connecting data islands and lakes'
-    subtitle = "Supported by DataLad and git-annex"
+    title = 'Technologies for distributed data management'
+    # subtitle = "Supported by DataLad and git-annex"
     imageUrl = "pics/distribits_logo_a.svg"
     imageTitle = "distribits_logo"
     imageWidth = 800

--- a/content/about.md
+++ b/content/about.md
@@ -3,3 +3,61 @@ title: "About"
 menu: "main"
 weight: 1
 ---
+
+---
+
+![Distribits 2024](/pics/distribits_logo_a.svg)
+## Technologies for distributed data management
+
+### April 18th - April 20th, 2024 at “Haus der Universität”, Düsseldorf, Germany
+
+---
+
+## Call for participation
+
+The first **distribits** meeting will happen in 2024, and we are inviting all interested parties to join!
+
+The aim of this meeting is to bring together enthusiasts of tools and workflows in the domain of distributed data.
+It is organized by the people behind the [git-annex](https://git-annex.branchable.com) and [DataLad](https://www.datalad.org) projects.
+The event will comprise a two-day conference and an additional hackathon day.
+
+
+### Conference
+
+We are planning the conference as a single-track event.
+Participation will be free of charge for attendees, but requires registration.
+Space is limited, so attendees will be selected and confirmed based on the information they provide in their registration.
+People who are actively contributing to the program will have priority.
+
+For this first meeting the format of contributions is pretty flexible. We envision, but are not limited to:
+
+1. **Talks:** presentations (ca. 20-30 minutes, final duration will be communicated to speakers) on research, case studies, practical applications or theoretical developments.
+2. **Lightning Talks:** quick five-minute presentations that introduce new ideas, projects, demo software, or share tips and tricks about workflows and tools.
+3. **Discussions:** moderated conversations with a panel about particular topics or issues. Proposals should include a list of panelists and a moderator.
+
+
+### Hackathon
+
+The conference will be followed by a hackathon day providing opportunities for attendees to further connect and collaborate in a more hands-on fashion.
+The capacity for this event is smaller. We thus ask everyone interested to indicate during the registration if they want to attend the hackathon, too. As we may receive more hackathon registrations than we can accommodate, attendees will be confirmed **separately** for the hackathon. A project proposal for this day or strong indication of interest during the registration can help us in the selection process.
+We plan to prioritize efforts that promote interoperability of tools and workflows with free and open solutions.
+
+
+### Audience
+
+We target a diverse audience to promote a stimulating exchange across professions, disciplines, and expertise.
+Attendees may include researchers, data stewards for collaborative initiatives, data scientists, software developers from academic or corporate environments, or simply enthusiastic individuals.
+Some people will have expertise with tools like git-annex and DataLad, but this is not a requirement for participation.
+
+Given the free nature of the event, attendees are expected to organize and cover their own travel, accommodation, and food.
+The event takes place in downtown Düsseldorf with plenty of options available.
+
+
+### Submit proposals and register
+
+Please submit your proposal and register via our [online submission/registration system](/registration).
+
+
+### Contact and further information
+
+For any further questions, please see https://distribits.live or contact distribits-org@fz-juelich.de


### PR DESCRIPTION
Adds content from https://github.com/datalad/distribits-2024/pull/16 to the About page as well as to the main index page. The latter is done via a theme update in: https://github.com/jsheunis/hugo-PaperMod/pull/1

This PR can be updated with any new changes to the call wording, etc.